### PR TITLE
feat: updates footer copyright and adds social links (#25)

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -5,7 +5,7 @@
   "intro": "Eine kleine Ecke des Internets — frei geboren — wo Ideen frei sein wollen, Code frei fließt und Köpfe sich verbinden.",
   "welcome": "Willkommen bei FWORKS",
   "footer": {
-    "copyright": "&copy; {{year}} FWORKS.TECH. Alle Rechte vorbehalten.",
+    "copyright": "{{year}} FWORKS.TECH. Alle Rechte vorbehalten.",
     "privacyPolicy": "Datenschutzerklärung"
   },
   "notFoundMessage": "Ups! Was du suchst, existiert nicht oder ist nicht das, was du erwartet hast.",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -5,7 +5,7 @@
   "intro": "A little corner of the internet — born free — where ideas want to be free, code flows openly, and minds connect.",
   "welcome": "Welcome to FWORKS",
   "footer": {
-    "copyright": "&copy; {{year}} FWORKS.TECH. All rights reserved.",
+    "copyright": "{{year}} FWORKS.TECH. All rights reserved.",
     "privacyPolicy": "Privacy Policy"
   },
   "notFoundMessage": "Oops! What you're looking for doesn't exist or isn't what you expected.",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -5,7 +5,7 @@
   "intro": "Un rincón en internet — nacido libre — donde las ideas quieren ser libres, el código fluye y las mentes se conectan.",
   "welcome": "Bienvenido a FWORKS",
   "footer": {
-    "copyright": "&copy; {{year}} FWORKS.TECH. Todos los derechos reservados.",
+    "copyright": "{{year}} FWORKS.TECH. Todos los derechos reservados.",
     "privacyPolicy": "Política de Privacidad"
   },
   "notFoundMessage": "¡Oops! Lo que buscas no existe o no es lo que esperabas.",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -5,7 +5,7 @@
   "intro": "Un petit coin d’internet — né libre — où les idées veulent être libres, le code circule librement et les esprits se connectent.",
   "welcome": "Bienvenue chez FWORKS",
   "footer": {
-    "copyright": "&copy; {{year}} FWORKS.TECH. Tous droits réservés.",
+    "copyright": "{{year}} FWORKS.TECH. Tous droits réservés.",
     "privacyPolicy": "Politique de Confidentialité"
   },
   "notFoundMessage": "Oups ! Ce que vous cherchez n’existe pas ou n’est pas ce que vous attendiez.",

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -5,7 +5,7 @@
   "intro": "Um cantinho na internet — que nasceu livre — onde ideias querem ser livres, códigos rolam soltos e mentes se conectam.",
   "welcome": "Bem-vindo à FWORKS",
   "footer": {
-    "copyright": "&copy; {{year}} FWORKS.TECH. Todos os direitos reservados.",
+    "copyright": "{{year}} FWORKS.TECH. Todos os direitos reservados.",
     "privacyPolicy": "Política de Privacidade"
   },
   "notFoundMessage": "Oops! O que você está procurando não existe ou não é o que você esperava.",

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -10,35 +10,40 @@ export default function Footer() {
 
   return (
     <footer
-      className={`mb-4 flex flex-col items-center justify-between py-6 text-center text-sm text-cyan-400 sm:text-base md:text-lg`}
+      className={`mb-4 flex flex-col items-center justify-center py-6 text-center text-sm text-cyan-400 sm:text-base md:text-lg`}
     >
       <p>
         © <span>{t('footer.copyright', { year })}</span>
-        <br />
-        <a href="/privacy" className={linksClassNames}>
+        <a href="/privacy" className={`${linksClassNames} my-1 block`}>
           {t('footer.privacyPolicy')}
         </a>
-        <br />
-        <br />
       </p>
-      <nav aria-label="Social links" className="mt-2 flex justify-center gap-2 text-sm">
-        <a
-          href="https://github.com/fworks-tech"
-          target="_blank"
-          rel="noopener noreferrer"
-          className={linksClassNames}
-        >
-          GitHub
-        </a>
-        <span>|</span>
-        <a
-          href="https://www.linkedin.com/in/fabiorborges"
-          target="_blank"
-          rel="noopener noreferrer"
-          className={linksClassNames}
-        >
-          LinkedIn
-        </a>
+      <nav aria-label="Social links" className="mt-4 p-2">
+        <ul className="mt-2 flex justify-center gap-2 text-sm">
+          <li>
+            <a
+              href="https://github.com/fworks-tech"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={linksClassNames}
+            >
+              GitHub
+            </a>
+          </li>
+          <li>
+            <span>|</span>
+          </li>
+          <li>
+            <a
+              href="https://www.linkedin.com/in/fabiorborges"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={linksClassNames}
+            >
+              LinkedIn
+            </a>
+          </li>
+        </ul>
       </nav>
     </footer>
   );

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -12,7 +12,7 @@ export default function Footer() {
     <footer className="mb-4 flex flex-col items-center justify-center py-6 text-center text-sm text-cyan-400 sm:text-base md:text-lg">
       <p>
         © <span>{t('footer.copyright', { year })}</span>
-        <a href="/privacy" className={linksClassNames + ' my-1 block'}>
+        <a href="/privacy" className={`${linksClassNames} my-1 block`}>
           {t('footer.privacyPolicy')}
         </a>
       </p>

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -10,7 +10,7 @@ export default function Footer() {
 
   return (
     <footer
-      className={`mb-4 flex flex-col items-center justify-center py-6 text-center text-sm text-cyan-400 sm:text-base md:text-lg`}
+      className="mb-4 flex flex-col items-center justify-center py-6 text-center text-sm text-cyan-400 sm:text-base md:text-lg"
     >
       <p>
         © <span>{t('footer.copyright', { year })}</span>

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -1,22 +1,45 @@
 import { useTranslation } from 'next-i18next';
 
+const TRANSLATION_NAMESPACE = 'common';
+
+const linksClassNames = `underline hover:text-cyan-300`;
+
 export default function Footer() {
-  const { t } = useTranslation('common');
+  const { t } = useTranslation(TRANSLATION_NAMESPACE);
   const year = new Date().getFullYear();
 
   return (
-    <footer className="align-center mb-4 flex flex-col justify-between py-6 text-center text-sm text-cyan-400 sm:text-base md:text-lg">
+    <footer
+      className={`mb-4 flex flex-col items-center justify-between py-6 text-center text-sm text-cyan-400 sm:text-base md:text-lg`}
+    >
       <p>
-        <span
-          dangerouslySetInnerHTML={{
-            __html: t('footer.copyright', { year })
-          }}
-        />
+        © <span>{t('footer.copyright', { year })}</span>
         <br />
-        <a href="/privacy" className="ml-2 underline hover:text-cyan-300">
+        <a href="/privacy" className={linksClassNames}>
           {t('footer.privacyPolicy')}
         </a>
+        <br />
+        <br />
       </p>
+      <nav aria-label="Social links" className="mt-2 flex justify-center gap-2 text-sm">
+        <a
+          href="https://github.com/fworks-tech"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={linksClassNames}
+        >
+          GitHub
+        </a>
+        <span>|</span>
+        <a
+          href="https://www.linkedin.com/in/fabiorborges"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={linksClassNames}
+        >
+          LinkedIn
+        </a>
+      </nav>
     </footer>
   );
 }

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -9,12 +9,10 @@ export default function Footer() {
   const year = new Date().getFullYear();
 
   return (
-    <footer
-      className="mb-4 flex flex-col items-center justify-center py-6 text-center text-sm text-cyan-400 sm:text-base md:text-lg"
-    >
+    <footer className="mb-4 flex flex-col items-center justify-center py-6 text-center text-sm text-cyan-400 sm:text-base md:text-lg">
       <p>
         © <span>{t('footer.copyright', { year })}</span>
-        <a href="/privacy" className={linksClassNames + " my-1 block"}>
+        <a href="/privacy" className={linksClassNames + ' my-1 block'}>
           {t('footer.privacyPolicy')}
         </a>
       </p>

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -14,7 +14,7 @@ export default function Footer() {
     >
       <p>
         © <span>{t('footer.copyright', { year })}</span>
-        <a href="/privacy" className={`${linksClassNames} my-1 block`}>
+        <a href="/privacy" className={linksClassNames + " my-1 block"}>
           {t('footer.privacyPolicy')}
         </a>
       </p>


### PR DESCRIPTION
(#25) This pull request updates the footer component and translation files to improve internationalization and usability. The main changes are a refactor of the copyright string in all supported languages, updates to the footer layout and styling, and the addition of social media links.

**Internationalization and Copyright Updates:**

* Removed the HTML entity `&copy;` from the copyright translation string in all supported languages (`public/locales/en/common.json`, `public/locales/de/common.json`, `public/locales/es/common.json`, `public/locales/fr/common.json`, `public/locales/pt/common.json`). The copyright symbol is now rendered directly in the component for consistency and easier translation maintenance. [[1]](diffhunk://#diff-4840952983d2a94f27deb00bf7247347345b60e3a96dc2aa41a6a50ecacdf1b6L8-R8) [[2]](diffhunk://#diff-70c84ede0085472d34ced2dbeb7e08c75c86df26f11878c97e348b5f654d784cL8-R8) [[3]](diffhunk://#diff-b1b8b7a0cd5fcde55685495746c15531f7c6fadeb5b6257b47a725560eb85477L8-R8) [[4]](diffhunk://#diff-394e5368f6e37bab07c78cfe6b0440bd1767cfecd5e967237e7baf0aa6be1568L8-R8) [[5]](diffhunk://#diff-9c9a86235b551e49a3e830e66e524f1cb90af76ddcf4f9374df4cf921c19e5c7L8-R8)

**Footer Component Improvements (`src/components/footer/index.tsx`):**

* Changed the layout to better center content and improved styling for responsiveness and accessibility.
* Refactored how the copyright string is rendered: the year is now interpolated and the copyright symbol is hardcoded in the component, removing the need for `dangerouslySetInnerHTML`.
* Added a navigation section with social media links to GitHub and LinkedIn, improving user engagement and discoverability.
* Centralized link styling with a `linksClassNames` variable for consistency across the footer.